### PR TITLE
Add ref to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Create an annotation of the build information and also list first n failed nunit
 
 Example
 ```yaml
-  - uses: MirrorNG/nunit-reporter
+  - uses: MirrorNG/nunit-reporter@1.0.4
       if: always()
       with:
         path: Tests/*.xml


### PR DESCRIPTION
Without this github shows this error:

```
Your workflow file was invalid: The workflow is not valid. .github/workflows/build.yml (Line: 50, Col: 13): Expected format {org}/{repo}[/path]@ref. Actual 'MirrorNG/nunit-reporter',Input string was not in a correct format.
```