### PR TITLE
fix: trim test report text

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5065,19 +5065,26 @@ async function run() {
         const accessToken = core_1.getInput('access-token');
         const results = await nunit_1.readResults(path);
         const octokit = new github_1.GitHub(accessToken);
-        const testSummary = results.annotations.map(generateSummary).join('\n');
         const summary = results.failed > 0
             ? `${results.failed} tests failed`
             : `${results.passed} tests passed`;
-        const details = results.failed === 0
+        let details = results.failed === 0
             ? `** ${results.passed} tests passed**`
             : `
 **${results.passed} tests passed**
 **${results.failed} tests failed**
-
-${testSummary}
-}
 `;
+        for (const ann of results.annotations) {
+            const annStr = generateSummary(ann);
+            const newDetails = `${details}\n${annStr}`;
+            if (newDetails.length > 65000) {
+                details = `${details}\n\n ... and more.`;
+                break;
+            }
+            else {
+                details = newDetails;
+            }
+        }
         await octokit.checks.create({
             head_sha: github_1.context.sha,
             name: 'Tests Results',


### PR DESCRIPTION
This prevents github rejecting too long reports:

Invalid request.
Only 65535 characters are allowed; N were supplied.