### PR TITLE
Fix test reports for PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5078,8 +5078,9 @@ async function run() {
 ${testSummary}
 }
 `;
+        const pr = github_1.context.payload.pull_request;
         await octokit.checks.create({
-            head_sha: github_1.context.sha,
+            head_sha: (pr && pr['head'] && pr['head'].sha) || github_1.context.sha,
             name: 'Tests Results',
             owner: github_1.context.repo.owner,
             repo: github_1.context.repo.repo,

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,8 +33,9 @@ async function run(): Promise<void> {
 ${testSummary}
 }
 `
+    const pr = context.payload.pull_request
     await octokit.checks.create({
-      head_sha: context.sha,
+      head_sha: (pr && pr['head'] && pr['head'].sha) || context.sha,
       name: 'Tests Results',
       owner: context.repo.owner,
       repo: context.repo.repo,


### PR DESCRIPTION
According to GitHub Actions documentation here:
https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
The sha and ref items are set to refs/pull/:num/merge for pull request events. Creating a Check for this ref will NOT show it in the pull request page on GitHub. Instead refs/pull/:num/head needs to be used.